### PR TITLE
Create transactional Foxx service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # ArangoACID
+
+ArangoACID is a Foxx microservice providing transactional write capabilities for ArangoDB.
+
+## Installation
+
+Use the Foxx CLI to install the service:
+
+```bash
+foxx install ./arango-acid /arango-acid
+```
+
+## Example Payload
+
+```json
+{
+  "schema": {},
+  "operations": [
+    {"collection": "users", "action": "insert", "data": {"_key": "bob", "name": "Bob"}}
+  ],
+  "foreignKeys": [
+    {"refCollection": "roles", "refField": "_key", "value": "admin"}
+  ]
+}
+```

--- a/arango-acid/lib/executor.js
+++ b/arango-acid/lib/executor.js
@@ -1,0 +1,30 @@
+'use strict';
+const db = require('@arangodb').db;
+
+function execute(operations) {
+  const collections = { write: [...new Set(operations.map(op => op.collection))] };
+  return db._executeTransaction({
+    collections,
+    params: { operations },
+    action: function (params) {
+      const db = require('@arangodb').db;
+      const results = [];
+      params.operations.forEach(op => {
+        const col = db._collection(op.collection);
+        if (!col) {
+          throw new Error(`Collection ${op.collection} not found`);
+        }
+        if (op.action === 'insert') {
+          results.push(col.save(op.data));
+        } else if (op.action === 'update') {
+          results.push(col.update(op.data._key, op.data));
+        } else if (op.action === 'remove') {
+          results.push(col.remove(op.data._key));
+        }
+      });
+      return results;
+    }
+  });
+}
+
+module.exports = { execute };

--- a/arango-acid/lib/fkCheck.js
+++ b/arango-acid/lib/fkCheck.js
@@ -1,0 +1,21 @@
+'use strict';
+const db = require('@arangodb').db;
+
+function check(foreignKeys) {
+  if (!foreignKeys) {
+    return true;
+  }
+  foreignKeys.forEach(fk => {
+    const col = db._collection(fk.refCollection);
+    if (!col) {
+      throw new Error(`Collection ${fk.refCollection} not found`);
+    }
+    const exists = col.firstExample(fk.refField, fk.value);
+    if (!exists) {
+      throw new Error(`Foreign key violation on ${fk.refCollection}`);
+    }
+  });
+  return true;
+}
+
+module.exports = { check };

--- a/arango-acid/lib/logger.js
+++ b/arango-acid/lib/logger.js
@@ -1,0 +1,13 @@
+'use strict';
+const db = require('@arangodb').db;
+const COLLECTION = 'transaction_log';
+let col = db._collection(COLLECTION);
+if (!col) {
+  col = db._create(COLLECTION);
+}
+
+function log(entry) {
+  col.save(Object.assign({ timestamp: Date.now() }, entry));
+}
+
+module.exports = { log };

--- a/arango-acid/lib/validator.js
+++ b/arango-acid/lib/validator.js
@@ -1,0 +1,21 @@
+'use strict';
+const Joi = require('joi');
+
+const operationSchema = Joi.object({
+  collection: Joi.string().required(),
+  action: Joi.string().valid('insert', 'update', 'remove').required(),
+  data: Joi.object().required()
+});
+
+function validateSchema(schema, operations) {
+  operations.forEach(op => {
+    const {error} = operationSchema.validate(op);
+    if (error) {
+      throw error;
+    }
+  });
+  // Additional schema checks can be implemented here using `schema` parameter
+  return true;
+}
+
+module.exports = { validateSchema };

--- a/arango-acid/main.js
+++ b/arango-acid/main.js
@@ -1,0 +1,8 @@
+'use strict';
+const createRouter = require('@arangodb/foxx/router');
+const router = createRouter();
+
+const transactionRoutes = require('./routes/transaction');
+router.use('/acid', transactionRoutes);
+
+module.context.use(router);

--- a/arango-acid/manifest.json
+++ b/arango-acid/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "arango-acid",
+  "version": "1.0.0",
+  "description": "Generic transactional microservice for ArangoDB",
+  "author": "OpenAI",
+  "license": "Apache-2.0",
+  "main": "main.js",
+  "engines": {
+    "arangodb": "^3.10.0"
+  },
+  "files": {
+    "lib": "./lib",
+    "routes": "./routes",
+    "schemas": "./schemas"
+  }
+}

--- a/arango-acid/routes/transaction.js
+++ b/arango-acid/routes/transaction.js
@@ -1,0 +1,31 @@
+'use strict';
+const createRouter = require('@arangodb/foxx/router');
+const Joi = require('joi');
+const validator = require('../lib/validator');
+const fkCheck = require('../lib/fkCheck');
+const executor = require('../lib/executor');
+
+const router = createRouter();
+router.tag('transaction');
+
+const payloadSchema = Joi.object({
+  schema: Joi.object().required(),
+  operations: Joi.array().items(Joi.object()).required(),
+  foreignKeys: Joi.array().items(Joi.object()).optional()
+}).required();
+
+router.post('/transaction', function (req, res) {
+  const payload = req.body;
+  validator.validateSchema(payload.schema, payload.operations);
+  if (payload.foreignKeys) {
+    fkCheck.check(payload.foreignKeys);
+  }
+  const result = executor.execute(payload.operations);
+  res.send(result);
+})
+.body(payloadSchema, 'Operations to execute atomically')
+.response(200, Joi.object().required(), 'Result of transaction')
+.summary('Run ACID transaction')
+.description('Validates and executes operations inside an atomic transaction.');
+
+module.exports = router;

--- a/arango-acid/schemas/example.schema.js
+++ b/arango-acid/schemas/example.schema.js
@@ -1,0 +1,7 @@
+'use strict';
+module.exports = {
+  example: {
+    _key: 'string',
+    name: 'string'
+  }
+};


### PR DESCRIPTION
## Summary
- add base Foxx microservice structure under `arango-acid`
- implement transaction endpoint and supporting libs
- provide example schema and README instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686be7a4f5388320a6142d016e98a295